### PR TITLE
Bump Jackson version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-smile</artifactId>
-      <version>2.6.2</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Attempting to run this locally resulted in a `NoSuchMethodError` from the `jackson-dataformat-smile` dependency as shown in the screenshot below. Bumping to the latest version of Jackson resolved this issue for me.

![Screenshot from 2024-04-01 12-11-47](https://github.com/FamilySearch/gedcom5-conversion/assets/2248695/ee765726-758f-4d57-88db-a894ad14ac70)
  